### PR TITLE
Fix inHull() for horizontal and vertical lines

### DIFF
--- a/tests/testthat/test-hull.R
+++ b/tests/testthat/test-hull.R
@@ -133,6 +133,16 @@ test_that("In hull (2D)", {
    res <- inHull(pt, vertices)
    expect_equal(res, c(0,0,0,0,-1))
 
+   vertices <- matrix(c(1,1, 1,2, 1,3), ncol = 2, byrow = TRUE) # vert. line
+   pt <- matrix(c(1,2, 1,3, 1,4), ncol = 2, byrow = TRUE)
+   res <- inHull(pt, vertices)
+   expect_equal(res, c(0,0,-1))
+
+   vertices <- matrix(c(1,1, 2,1, 3,1), ncol = 2, byrow = TRUE) # horiz. line
+   pt <- matrix(c(2,1, 3,1, 4,1), ncol = 2, byrow = TRUE)
+   res <- inHull(pt, vertices)
+   expect_equal(res, c(0,0,-1))
+
    vertices <- matrix(c(0,0, 0,3, 3,0), ncol = 2, byrow = TRUE)
    pt <- matrix(c(0,0, 1,1, 4,4), ncol = 2, byrow = TRUE)
    res <- inHull(pt, vertices)


### PR DESCRIPTION
First, thank you for your package, for developing it on GitHub, and for having a nice suite of tests for it!

This PR fixes handling of horizontal and vertical lines. The previous code would return NA in some cases because of a division by zero. I'm not confident at all that my proposed fix is the most simple or most efficient, but perhaps it will give a clue for a better fix. For example, maybe there's a simple way to handle all cases together, rather than handling vertical and horizontal lines separately from other types of lines (as I do in the commit).

By the way, cool style for entering matrices in the tests. I haven't seen that style before.

Here are a couple of examples for what this PR fixes:

```
library("gMOIP")

vertices <- matrix(c(1,1, 1,2, 1,3), ncol = 2, byrow = TRUE)
pt <- matrix(c(1,2, 1,3, 1,4), ncol = 2, byrow = TRUE)

res <- inHull(pt, vertices)
res_expected <- c(0,0,-1)


vertices <- matrix(c(1,1, 2,1, 3,1), ncol = 2, byrow = TRUE)
pt <- matrix(c(2,1, 3,1, 4,1), ncol = 2, byrow = TRUE)

res <- inHull(pt, vertices)
res_expected <- c(0,0,-1)
```