### PR TITLE
Change rgl.* to *3d

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ License: GPL (>= 3.3.2)
 Language: en-US
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.1
+RoxygenNote: 7.2.3
 Roxygen: list(markdown = TRUE)
 Depends: R (>= 3.5.0)
 Imports: 
@@ -52,5 +52,5 @@ Suggests:
     pdftools,
     testthat (>= 2.1.0),
     webshot2
-Additional_repositories:  https://dmurdoch.github.io/drat
+Additional_repositories: https://dmurdoch.github.io/drat
 VignetteBuilder: knitr

--- a/R/functions.R
+++ b/R/functions.R
@@ -78,7 +78,7 @@ cornerPoints <- function (A, b, type = rep("c", ncol(A)), nonneg = rep(TRUE, nco
    p <- slices(A, b, type, nonneg)
    p <- do.call(rbind, p)
    tri <- t(geometry::convhulln(p))
-   #rgl.triangles(p[tri,1],p[tri,2],p[tri,3],col="gold2",alpha=.6)
+   #triangles3d(p[tri,1],p[tri,2],p[tri,3],col="gold2",alpha=.6)
    idx <- unique(as.vector(tri))
    p <- p[idx,]
    #points3d(p, col="blue", size = 15)

--- a/R/hull.R
+++ b/R/hull.R
@@ -435,7 +435,7 @@ convexHull <- function(pts, addRays = FALSE, useRGLBBox = FALSE, direction = 1,
    if (length(direction) != p) direction = rep(direction[1],p)
    # print(set)
    if (addRays) {
-      if (rgl::rgl.cur() > 0 & useRGLBBox) {
+      if (rgl::cur3d() > 0 & useRGLBBox) {
          limits <- rgl::par3d()$bbox
          for (i in 1:dim(pts)[1]) {
             pt <- as.vector(pts[i,])

--- a/R/plot.R
+++ b/R/plot.R
@@ -798,7 +798,7 @@ saveView <- function(fname = "view.RData", overwrite = FALSE, print = FALSE) {
 #' @param fname The file name of the view.
 #' @param v The view matrix.
 #' @param clear Call [rgl::clear3d].
-#' @param close Call [rgl::rgl.close].
+#' @param close Call [rgl::close3d].
 #' @param zoom Zoom level.
 #' @param ... Additional parameters passed to [rgl::view3d].
 #'
@@ -822,7 +822,7 @@ saveView <- function(fname = "view.RData", overwrite = FALSE, print = FALSE) {
 #' }
 loadView <- function(fname = "view.RData", v = NULL, clear = TRUE, close = FALSE, zoom = 1, ...) {
    if (clear) rgl::clear3d()
-   if (close) rgl::rgl.close()
+   if (close) rgl::close3d()
    if (!is.null(v)) {
       rgl::view3d(userMatrix = v, zoom = zoom, ...)
    } else {
@@ -992,7 +992,7 @@ plotNDSet2D <- function(points,
 #'            argsPlot3d = list(size=2, type="s", alpha=0.3))
 #' ids <- plotRectangle3D(c(2,2,2), c(3,3,2.5), argsPolygon3d = list(alpha = 1) )
 #' finalize3D()
-#' # rgl.pop(id = ids) remove last object
+#' # pop3d(id = ids) remove last object
 #' }
 plotRectangle3D <- function(a, b, ...) {
    args <- list(...)
@@ -1067,7 +1067,7 @@ plotRectangle3D <- function(a, b, ...) {
 #' ids <- plotPolygon3D(pts, usePoints = TRUE, useShade = TRUE,
 #'               argsPoints = list(color = "blue", texture = getTexture(pch = 16, cex = 20)))
 #' finalize3D()
-#' # rgl.pop(id = ids) # remove object again
+#' # pop3d(id = ids) # remove object again
 #'
 #' # In general you have to finetune size and numbers when you use textures
 #' # Different pch
@@ -1140,7 +1140,7 @@ plotPolygon3D <- function(pts, useShade = TRUE, useLines = FALSE, usePoints = FA
       ids <- c(ids, do.call(rgl::shade3d, args = c(list(poly), argsPoints)))
    }
    if (useLines) {
-      if (!rgl::rgl.cur()) stop("Option useLines need an open rgl window!")
+      if (!rgl::cur3d()) stop("Option useLines need an open rgl window!")
       limits <- rgl::par3d()$bbox
       m <- c(limits[1], limits[3], limits[5])
       M <- c(limits[2], limits[4], limits[6])
@@ -1233,7 +1233,7 @@ getTexture <- function(pch = 16, cex = 10, ...) {
 #' plotCones3D(c(4,2,2), direction = c(1,-1,-1))
 #' ids <- plotCones3D(c(2,2,4), direction = c(-1,-1,1))
 #' finalize3D()
-#' # rgl.pop(id = ids) # remove last cone
+#' # pop3d(id = ids) # remove last cone
 #' }
 plotCones3D <-
    function(pts,
@@ -1365,7 +1365,7 @@ plotCones2D <-
 #' pts<-matrix(c(5,5,5,10,10,5,10,5,5,5,5,10), ncol = 3, byrow = TRUE)
 #' lst <- plotHull3D(pts, argsPolygon3d = list(alpha=0.9), argsSegments3d = list(color="red"))
 #' finalize3D()
-#' # rgl.pop(id = lst$ids) # remove last hull
+#' # pop3d(id = lst$ids) # remove last hull
 #'
 #' ## Using addRays
 #' pts <- data.frame(x = c(1,3), y = c(1,3), z = c(1,3))
@@ -1590,7 +1590,7 @@ plotHull3D <- function(pts,
 #' ids <- plotPoints3D(c(3,3,3, 4,4,4), addText = "rownames")
 #' finalize3D()
 #' rgl::rglwidget()
-#' # rgl.pop(ids) # remove the last again
+#' # pop3d(ids) # remove the last again
 #' }
 plotPoints3D <- function(pts, addText = FALSE, ...) {
    args <- list(...)
@@ -1663,7 +1663,7 @@ plotPoints3D <- function(pts, addText = FALSE, ...) {
 #' ids <- plotPlane3D(c(1,2,1), point = c(2,2,2), argsLines = list(col="blue", lines = 100),
 #'             useLines = TRUE)
 #' finalize3D()
-#' # rgl.pop(id = ids) # remove last plane
+#' # pop3d(id = ids) # remove last plane
 #' }
 plotPlane3D <- function(normal, point = NULL, offset = 0, useShade = TRUE, useLines = FALSE,
                         usePoints = FALSE, ...) {
@@ -1678,7 +1678,7 @@ plotPlane3D <- function(normal, point = NULL, offset = 0, useShade = TRUE, useLi
       ids <- c(ids, do.call(rgl::planes3d, args = c(list(normal, d = offset), argsPlanes3d) ))
    }
    # else use points or lines
-   if (!rgl::rgl.cur()) stop("Option useLines or usePoints need an open rgl window!")
+   if (!rgl::cur3d()) stop("Option useLines or usePoints need an open rgl window!")
    limits <- rgl::par3d()$bbox
    m <- c(limits[1], limits[3], limits[5])
    M <- c(limits[2], limits[4], limits[6])

--- a/man/gMOIP-package.Rd
+++ b/man/gMOIP-package.Rd
@@ -6,12 +6,7 @@
 \alias{gMOIP-package}
 \title{gMOIP: Tools for 2D and 3D Plots of Single and Multi-Objective Linear/Integer Programming Models}
 \description{
-Make 2D and 3D plots of linear programming (LP), 
-    integer linear programming (ILP), or mixed integer linear programming (MILP) models 
-    with up to three objectives. Plots of both the solution and criterion space are possible.
-    For instance the non-dominated (Pareto) set for bi-objective LP/ILP/MILP programming models 
-    (see vignettes for an overview). The package also contains an function for checking if a point
-    is inside the convex hull.
+Make 2D and 3D plots of linear programming (LP), integer linear programming (ILP), or mixed integer linear programming (MILP) models with up to three objectives. Plots of both the solution and criterion space are possible. For instance the non-dominated (Pareto) set for bi-objective LP/ILP/MILP programming models (see vignettes for an overview). The package also contains an function for checking if a point is inside the convex hull.
 }
 \seealso{
 \link{plotPolytope}, \link{plotCriterion2D} and \link{plotHull3D}.

--- a/man/loadView.Rd
+++ b/man/loadView.Rd
@@ -20,7 +20,7 @@ loadView(
 
 \item{clear}{Call \link[rgl:scene]{rgl::clear3d}.}
 
-\item{close}{Call \link[rgl:rgl.open]{rgl::rgl.close}.}
+\item{close}{Call \link[rgl:open3d]{rgl::close3d}.}
 
 \item{zoom}{Zoom level.}
 

--- a/man/plotCones3D.Rd
+++ b/man/plotCones3D.Rd
@@ -36,7 +36,7 @@ i'th column of \code{pts} minus a value greater than on equal zero (maximize obj
 lists (see examples). Currently the following arguments are supported:
 \itemize{
 \item \code{argsPlot3d}: A list of arguments for \code{\link[rgl:plot3d]{rgl::plot3d}}.
-\item \code{argsSegments3d}: A list of arguments for \code{\link[rgl:3dobjects]{rgl::segments3d}}.
+\item \code{argsSegments3d}: A list of arguments for \code{\link[rgl:primitives]{rgl::segments3d}}.
 \item \code{argsPolygon3d}: A list of arguments for \code{\link[rgl:polygon3d]{rgl::polygon3d}}.
 }}
 }
@@ -62,6 +62,6 @@ plotCones3D(c(2,2,2), direction = -1)
 plotCones3D(c(4,2,2), direction = c(1,-1,-1))
 ids <- plotCones3D(c(2,2,4), direction = c(-1,-1,1))
 finalize3D()
-# rgl.pop(id = ids) # remove last cone
+# pop3d(id = ids) # remove last cone
 }
 }

--- a/man/plotHull3D.Rd
+++ b/man/plotHull3D.Rd
@@ -43,7 +43,7 @@ i'th column of \code{pts} minus a value greater than on equal zero (maximize obj
 lists (see examples). Currently the following arguments are supported:
 \itemize{
 \item \code{argsPlot3d}: A list of arguments for \code{\link[rgl:plot3d]{rgl::plot3d}}.
-\item \code{argsSegments3d}: A list of arguments for \code{\link[rgl:3dobjects]{rgl::segments3d}}.
+\item \code{argsSegments3d}: A list of arguments for \code{\link[rgl:primitives]{rgl::segments3d}}.
 \item \code{argsPolygon3d}: A list of arguments for \code{\link[rgl:polygon3d]{rgl::polygon3d}}.
 \item \code{argsShade3d}: A list of arguments for \code{\link[rgl:mesh3d]{rgl::shade3d}}.
 \item \code{argsText3d}: A list of arguments for \code{\link[rgl:texts]{rgl::text3d}}.
@@ -67,7 +67,7 @@ plotHull3D(pts, drawLines = FALSE, argsPolygon3d = list(alpha=0.6)) # a polygon
 pts<-matrix(c(5,5,5,10,10,5,10,5,5,5,5,10), ncol = 3, byrow = TRUE)
 lst <- plotHull3D(pts, argsPolygon3d = list(alpha=0.9), argsSegments3d = list(color="red"))
 finalize3D()
-# rgl.pop(id = lst$ids) # remove last hull
+# pop3d(id = lst$ids) # remove last hull
 
 ## Using addRays
 pts <- data.frame(x = c(1,3), y = c(1,3), z = c(1,3))

--- a/man/plotPlane3D.Rd
+++ b/man/plotPlane3D.Rd
@@ -57,6 +57,6 @@ plotPlane3D(c(1,1,1), point = c(1,1,1), useLines = TRUE, useShade = TRUE)
 ids <- plotPlane3D(c(1,2,1), point = c(2,2,2), argsLines = list(col="blue", lines = 100),
             useLines = TRUE)
 finalize3D()
-# rgl.pop(id = ids) # remove last plane
+# pop3d(id = ids) # remove last plane
 }
 }

--- a/man/plotPoints3D.Rd
+++ b/man/plotPoints3D.Rd
@@ -38,6 +38,6 @@ plotPoints3D(c(2,2,2, 1,1,1), addText = "coord")
 ids <- plotPoints3D(c(3,3,3, 4,4,4), addText = "rownames")
 finalize3D()
 rgl::rglwidget()
-# rgl.pop(ids) # remove the last again
+# pop3d(ids) # remove the last again
 }
 }

--- a/man/plotPolygon3D.Rd
+++ b/man/plotPolygon3D.Rd
@@ -28,9 +28,9 @@ plotPolygon3D(
 lists (see examples). Currently the following arguments are supported:
 \itemize{
 \item \code{argsShade}: A list of arguments for \code{\link[rgl:polygon3d]{rgl::polygon3d}} (n > 4 vertices),
-\link[rgl:3dobjects]{rgl::triangles3d} (n = 3 vertices) and \link[rgl:3dobjects]{rgl::quads3d} (n = 4 vertices)
+\link[rgl:primitives]{rgl::triangles3d} (n = 3 vertices) and \link[rgl:primitives]{rgl::quads3d} (n = 4 vertices)
 if \code{useShade = TRUE}.
-\item \code{argsFrame}: A list of arguments for \code{\link[rgl:3dobjects]{rgl::lines3d}} if \code{useFrame = TRUE}.
+\item \code{argsFrame}: A list of arguments for \code{\link[rgl:primitives]{rgl::lines3d}} if \code{useFrame = TRUE}.
 \item \code{argsPoints}: A list of arguments for \code{\link[rgl:shade3d]{rgl::shade3d}} if \code{usePoints = TRUE}. It is important
 to give a texture using \code{texture}. A texture can be set using \link{getTexture}.
 \item \code{argsLines}: A list of arguments for \link[rgl:persp3d]{rgl::persp3d} when \code{useLines = TRUE}. Moreover, the list
@@ -71,7 +71,7 @@ ini3D()
 ids <- plotPolygon3D(pts, usePoints = TRUE, useShade = TRUE,
               argsPoints = list(color = "blue", texture = getTexture(pch = 16, cex = 20)))
 finalize3D()
-# rgl.pop(id = ids) # remove object again
+# pop3d(id = ids) # remove object again
 
 # In general you have to finetune size and numbers when you use textures
 # Different pch

--- a/man/plotPolytope.Rd
+++ b/man/plotPolytope.Rd
@@ -83,18 +83,18 @@ lists. Currently the following arguments are supported:
 \item \code{argsFaces}: A list of arguments for \code{\link{plotHull3D}}.
 \item \code{argsFeasible}: A list of arguments for rgl functions:
 \itemize{
-\item \code{points3d}: A list of arguments for \code{\link[rgl:3dobjects]{rgl::points3d}}.
-\item \code{segments3d}: A list of arguments for \code{\link[rgl:3dobjects]{rgl::segments3d}}.
-\item \code{triangles3d}: A list of arguments for \code{\link[rgl:3dobjects]{rgl::triangles3d}}.
+\item \code{points3d}: A list of arguments for \code{\link[rgl:primitives]{rgl::points3d}}.
+\item \code{segments3d}: A list of arguments for \code{\link[rgl:primitives]{rgl::segments3d}}.
+\item \code{triangles3d}: A list of arguments for \code{\link[rgl:primitives]{rgl::triangles3d}}.
 }
 \item \code{argsLabels}: A list of arguments for rgl functions:
 \itemize{
-\item \code{points3d}: A list of arguments for \code{\link[rgl:3dobjects]{rgl::points3d}}.
+\item \code{points3d}: A list of arguments for \code{\link[rgl:primitives]{rgl::points3d}}.
 \item \code{text3d}: A list of arguments for \code{\link[rgl:texts]{rgl::text3d}}.
 }
 \item \code{argsOptimum}: A list of arguments for rgl functions:
 \itemize{
-\item \code{points3d}: A list of arguments for \code{\link[rgl:3dobjects]{rgl::points3d}}.
+\item \code{points3d}: A list of arguments for \code{\link[rgl:primitives]{rgl::points3d}}.
 }
 }}
 }

--- a/man/plotPolytope3D.Rd
+++ b/man/plotPolytope3D.Rd
@@ -61,18 +61,18 @@ lists. Currently the following arguments are supported:
 \item \code{argsFaces}: A list of arguments for \code{\link{plotHull3D}}.
 \item \code{argsFeasible}: A list of arguments for rgl functions:
 \itemize{
-\item \code{points3d}: A list of arguments for \code{\link[rgl:3dobjects]{rgl::points3d}}.
-\item \code{segments3d}: A list of arguments for \code{\link[rgl:3dobjects]{rgl::segments3d}}.
-\item \code{triangles3d}: A list of arguments for \code{\link[rgl:3dobjects]{rgl::triangles3d}}.
+\item \code{points3d}: A list of arguments for \code{\link[rgl:primitives]{rgl::points3d}}.
+\item \code{segments3d}: A list of arguments for \code{\link[rgl:primitives]{rgl::segments3d}}.
+\item \code{triangles3d}: A list of arguments for \code{\link[rgl:primitives]{rgl::triangles3d}}.
 }
 \item \code{argsLabels}: A list of arguments for rgl functions:
 \itemize{
-\item \code{points3d}: A list of arguments for \code{\link[rgl:3dobjects]{rgl::points3d}}.
+\item \code{points3d}: A list of arguments for \code{\link[rgl:primitives]{rgl::points3d}}.
 \item \code{text3d}: A list of arguments for \code{\link[rgl:texts]{rgl::text3d}}.
 }
 \item \code{argsOptimum}: A list of arguments for rgl functions:
 \itemize{
-\item \code{points3d}: A list of arguments for \code{\link[rgl:3dobjects]{rgl::points3d}}.
+\item \code{points3d}: A list of arguments for \code{\link[rgl:primitives]{rgl::points3d}}.
 }
 }}
 }

--- a/man/plotRectangle3D.Rd
+++ b/man/plotRectangle3D.Rd
@@ -15,7 +15,7 @@ plotRectangle3D(a, b, ...)
 lists (see examples). Currently the following arguments are supported:
 \itemize{
 \item \code{argsPlot3d}: A list of arguments for \code{\link[rgl:plot3d]{rgl::plot3d}}.
-\item \code{argsSegments3d}: A list of arguments for \code{\link[rgl:3dobjects]{rgl::segments3d}}.
+\item \code{argsSegments3d}: A list of arguments for \code{\link[rgl:primitives]{rgl::segments3d}}.
 \item \code{argsPolygon3d}: A list of arguments for \code{\link[rgl:polygon3d]{rgl::polygon3d}}.
 \item \code{argsShade3d}: A list of arguments for \code{\link[rgl:mesh3d]{rgl::shade3d}}.
 }}
@@ -35,6 +35,6 @@ plotRectangle3D(c(1,1,1), c(4,4,3), drawPoints = TRUE, drawLines = FALSE,
            argsPlot3d = list(size=2, type="s", alpha=0.3))
 ids <- plotRectangle3D(c(2,2,2), c(3,3,2.5), argsPolygon3d = list(alpha = 1) )
 finalize3D()
-# rgl.pop(id = ids) remove last object
+# pop3d(id = ids) remove last object
 }
 }


### PR DESCRIPTION
Some upcoming changes to the rgl package will require changes to gMOIP.  I will be deprecating a number of rgl.* function calls.  You can read about the issues here:

      https://dmurdoch.github.io/rgl/articles/deprecation.html

I have made the required changes to gMOIP in the attached patch. These changes should work with both old and new rgl versions.